### PR TITLE
fails to install packages

### DIFF
--- a/vpn/vpn.yml
+++ b/vpn/vpn.yml
@@ -17,7 +17,7 @@
 
   tasks:
     - name: Install required packages with apt
-      apt: name=$item state=latest update_cache=yes
+      apt: name={{item}} state=latest update_cache=yes
       with_items:
         - openswan
         - xl2tpd


### PR DESCRIPTION
errors out with 
"msg: No package matching '$item' is available" 
when $item is set, works when set to {{item}}
